### PR TITLE
Add paperclip-style factory mechanics

### DIFF
--- a/Universal Psychology/index.html
+++ b/Universal Psychology/index.html
@@ -76,6 +76,13 @@
                         <div id="neuron-proliferation-upgrades-list"></div>
                     </section>
 
+                    <section id="factory-area" style="display: none;">
+                        <h2>Neuron Factories</h2>
+                        <p>Factories: <span id="factory-count">0</span></p>
+                        <p>Cost: <span id="factory-cost">10</span> Psychbucks</p>
+                        <button id="buy-factory-btn">Buy Factory</button>
+                    </section>
+
                     <section id="hypothalamus-controls-area" style="display: none;">
                         <h2>Hypothalamus Controls</h2>
                         <div id="dopamine-control">
@@ -95,14 +102,9 @@
         </div>
     </div>
 
-  <!-- NEW: Overlay for Scary Stimuli -->
+    <!-- NEW: Overlay for Scary Stimuli -->
         <div id="scary-stimuli-overlay"></div>
     </div>
-
-    <script type="module" src="three_scene.js"></script>
-    <script type="module" src="game_logic.js"></script>
-</body>
-</html>
 
     <script type="module" src="three_scene.js"></script>
     <script type="module" src="game_logic.js"></script>


### PR DESCRIPTION
## Summary
- add new "Neuron Factory" section to unlock after Brain Growth I
- track factory count/cost in game state and update display
- implement buying factories to increase passive neuron generation
- cleanup duplicate HTML

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6847b169a9c48327941d9ae53c854d3d