### PR TITLE
Add help overlay

### DIFF
--- a/Universal Psychology/game_logic.js
+++ b/Universal Psychology/game_logic.js
@@ -102,6 +102,9 @@ document.addEventListener('DOMContentLoaded', async () => {
     const neurofuelCountDOM = document.getElementById('neurofuel-count');
     const neurofuelCostDOM = document.getElementById('neurofuel-cost');
     const buyNeurofuelBtnDOM = document.getElementById('buy-neurofuel-btn');
+    const infoButtonDOM = document.getElementById('info-button');
+    const instructionsOverlayDOM = document.getElementById('instructions-overlay');
+    const closeInstructionsBtnDOM = document.getElementById('close-instructions');
 
     // --- 4. RAW DATA ---
     const coreUpgrades_raw_data = [
@@ -329,6 +332,12 @@ document.addEventListener('DOMContentLoaded', async () => {
         if (gabaSliderDOM) gabaSliderDOM.addEventListener('input', handleGabaSlider); else console.warn("GABA slider not found.");
         if (buyFactoryBtnDOM) buyFactoryBtnDOM.addEventListener('click', handleBuyFactory);
         if (buyNeurofuelBtnDOM) buyNeurofuelBtnDOM.addEventListener('click', handleBuyNeurofuel);
+        if (infoButtonDOM) infoButtonDOM.addEventListener('click', () => {
+            if (instructionsOverlayDOM) instructionsOverlayDOM.style.display = 'flex';
+        });
+        if (closeInstructionsBtnDOM) closeInstructionsBtnDOM.addEventListener('click', () => {
+            if (instructionsOverlayDOM) instructionsOverlayDOM.style.display = 'none';
+        });
         const btnDebugNeurons = document.getElementById('debug-add-neurons');
         const btnDebugPsychbucks = document.getElementById('debug-add-psychbucks');
         if (btnDebugNeurons) btnDebugNeurons.addEventListener('click', () => { gameState.neurons += 1000; UIManager.updateAllDisplays(); UIManager.logMessage("DEBUG: +1000 Neurons", "log-info"); }); else console.warn("Debug neurons button not found.");

--- a/Universal Psychology/index.html
+++ b/Universal Psychology/index.html
@@ -118,6 +118,20 @@
 
     <!-- NEW: Overlay for Scary Stimuli -->
         <div id="scary-stimuli-overlay"></div>
+
+    <!-- Instructions Overlay -->
+        <div id="instructions-overlay">
+            <div id="instructions-content">
+                <h2>How to Play</h2>
+                <p>Click <strong>Add Neurons</strong> to gain neurons or build factories for passive income.</p>
+                <p>Spend neurons to buy upgrades. These unlock new features and improve production.</p>
+                <p><strong>Psychbucks</strong> accumulate from factories and projects. Use them for advanced upgrades.</p>
+                <p>Manual neuron generation consumes <strong>Fuel</strong>. Purchase food to refill it.</p>
+                <button id="close-instructions">Close</button>
+            </div>
+        </div>
+
+        <button id="info-button">?</button>
     </div>
 
     <script type="module" src="three_scene.js"></script>

--- a/Universal Psychology/style.css
+++ b/Universal Psychology/style.css
@@ -391,3 +391,47 @@ button:hover {
 #projects-area {
     display: block;
 }
+
+/* Info Button */
+#info-button {
+    position: fixed;
+    bottom: 15px;
+    right: 15px;
+    width: 40px;
+    height: 40px;
+    border: none;
+    border-radius: 50%;
+    background-color: #007bff;
+    color: #fff;
+    font-size: 20px;
+    cursor: pointer;
+    z-index: 1100;
+}
+
+/* Instructions Overlay */
+#instructions-overlay {
+    display: none;
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100vw;
+    height: 100vh;
+    background-color: rgba(0, 0, 0, 0.7);
+    justify-content: center;
+    align-items: center;
+    z-index: 1200;
+}
+
+#instructions-content {
+    background-color: #fff;
+    padding: 20px;
+    border-radius: 8px;
+    max-width: 600px;
+    max-height: 80vh;
+    overflow-y: auto;
+    text-align: left;
+}
+
+#instructions-content button {
+    margin-top: 10px;
+}


### PR DESCRIPTION
## Summary
- add instructions overlay and info button to open it
- style the overlay and button
- wire up button listeners in the game logic

## Testing
- `npm test` *(fails: Could not find package.json)*
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_6847c80cc8008327908c76507042a07f