### PR TITLE
Add proliferation factory and tweak neuron upgrades

### DIFF
--- a/Universal Psychology/index.html
+++ b/Universal Psychology/index.html
@@ -80,10 +80,10 @@
                     </section>
 
                     <section id="factory-area" style="display: none;">
-                        <h2>Neuron Factories</h2>
+                        <h2>Proliferation Factories</h2>
                         <p>Factories: <span id="factory-count">0</span></p>
                         <p>Cost: <span id="factory-cost">10</span> Psychbucks</p>
-                        <button id="buy-factory-btn">Buy Factory</button>
+                        <button id="buy-factory-btn">Buy Proliferation Factory</button>
                     </section>
 
                     <section id="neurofuel-area">
@@ -124,9 +124,9 @@
         <div id="instructions-overlay">
             <div id="instructions-content">
                 <h2>How to Play</h2>
-                <p>Click <strong>Add Neurons</strong> to gain neurons or build factories for passive income.</p>
+                <p>Click <strong>Add Neurons</strong> to gain neurons or build proliferation factories for passive income.</p>
                 <p>Spend neurons to buy upgrades. These unlock new features and improve production.</p>
-                <p><strong>Psychbucks</strong> accumulate from factories and projects. Use them for advanced upgrades.</p>
+                <p><strong>Psychbucks</strong> accumulate from proliferation factories and projects. Use them for advanced upgrades.</p>
                 <p>Manual neuron generation consumes <strong>Fuel</strong>. Purchase food to refill it.</p>
                 <button id="close-instructions">Close</button>
             </div>


### PR DESCRIPTION
## Summary
- rename factory UI to "Proliferation Factory"
- add passive neuro fuel multiplier variable
- overhaul proliferation upgrades with dendritic sprouting and myelination
- support percentage boosts and fuel/anxiety effects
- adjust passive fuel consumption and factory handler

## Testing
- `node --check 'Universal Psychology/game_logic.js'`

------
https://chatgpt.com/codex/tasks/task_e_6847cbe44c548327ab53cd8b6be90779