### PR TITLE
Add metabolic efficiency upgrade and brain popup

### DIFF
--- a/Universal Psychology/index.html
+++ b/Universal Psychology/index.html
@@ -120,6 +120,14 @@
     <!-- NEW: Overlay for Scary Stimuli -->
         <div id="scary-stimuli-overlay"></div>
 
+    <!-- Brain Stats Popup -->
+        <div id="brain-popup" class="popup-overlay">
+            <div id="brain-popup-content">
+                <canvas id="brain-stats-chart"></canvas>
+                <button id="close-brain-popup">Close</button>
+            </div>
+        </div>
+
     <!-- Instructions Overlay -->
         <div id="instructions-overlay">
             <div id="instructions-content">
@@ -135,6 +143,7 @@
         <button id="info-button">?</button>
     </div>
 
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <script type="module" src="three_scene.js"></script>
     <script type="module" src="game_logic.js"></script>
 </body>

--- a/Universal Psychology/style.css
+++ b/Universal Psychology/style.css
@@ -31,7 +31,7 @@ body {
     display: flex;
     flex-direction: column;
     overflow: hidden;
-    padding: 15px;
+    padding: 10px;
 }
 
 /* Info Banner */
@@ -137,9 +137,9 @@ body {
 }
 #threejs-canvas-container {
     flex-grow: 1;
-    aspect-ratio: 16 / 9; 
-    max-height: 220px; 
-    min-height: 150px; 
+    aspect-ratio: 4 / 3;
+    max-height: 160px;
+    min-height: 120px;
     border: 1px solid #ccc;
     background-color: #000;
     position: relative;
@@ -435,4 +435,30 @@ button:hover {
 
 #instructions-content button {
     margin-top: 10px;
+}
+
+/* Brain Popup Overlay */
+#brain-popup.popup-overlay {
+    display: none;
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100vw;
+    height: 100vh;
+    background-color: rgba(0,0,0,0.7);
+    justify-content: center;
+    align-items: center;
+    z-index: 1300;
+}
+#brain-popup-content {
+    background-color: #fff;
+    padding: 20px;
+    border-radius: 8px;
+    width: 80vw;
+    max-width: 800px;
+}
+#brain-popup-content canvas {
+    width: 100%;
+    height: 300px;
+    margin-bottom: 10px;
 }


### PR DESCRIPTION
## Summary
- halve neurofuel use with new `Metabolic Efficiency` upgrade
- track fuel and neurons over time and display them in a popup chart
- shrink the brain visualizer to free space
- show chart popup when the brain is clicked

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_6848bc3360c48327a5aa7db4bf59be7a