### PR TITLE
Implement factory gating & reorder UI

### DIFF
--- a/Universal Psychology/index.html
+++ b/Universal Psychology/index.html
@@ -74,16 +74,16 @@
                         <div id="upgrades-list"></div>
                     </section>
 
-                    <section id="neuron-proliferation-area" style="display: none;">
-                        <h2>Neuron Proliferation</h2>
-                        <div id="neuron-proliferation-upgrades-list"></div>
-                    </section>
-
                     <section id="factory-area" style="display: none;">
                         <h2>Proliferation Factories</h2>
                         <p>Factories: <span id="factory-count">0</span></p>
                         <p>Cost: <span id="factory-cost">10</span> Psychbucks</p>
                         <button id="buy-factory-btn">Buy Proliferation Factory</button>
+                    </section>
+
+                    <section id="neuron-proliferation-area" style="display: none;">
+                        <h2>Neuron Proliferation</h2>
+                        <div id="neuron-proliferation-upgrades-list"></div>
                     </section>
 
                     <section id="neurofuel-area">


### PR DESCRIPTION
## Summary
- gate the factory area behind the neuron proliferation upgrade
- remove myelination dependency for metabolic efficiency and unlock after 4 factories
- check factory requirement when showing upgrades
- reorder factory UI before neuron proliferation

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6848de2222348327be9e7f452e8e84ed