### PR TITLE
Update postbuild to use node copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ A Vite dev server will start.
 ```bash
 npm run build
 ```
-
-After the build completes, copy the contents of `pokies-react/dist/` into `Universal Psychology/pokies-react/` so that the latest assets are available to the main game.
+The build command automatically runs a `postbuild` script that copies the contents
+of `pokies-react/dist/` into `Universal Psychology/pokies-react/` using Node's
+filesystem API. This ensures the latest assets are available to the main game.
 

--- a/pokies-react/README.md
+++ b/pokies-react/README.md
@@ -14,14 +14,15 @@ The app will start with Vite and render a simple slot machine that can be spun u
 ## Build & Deploy
 
 Running a production build will output the compiled files to `dist/` and then
-copy them into the main project under `../Universal Psychology/pokies-react/`.
+copy them into the main project under `../Universal Psychology/pokies-react/`
+using a small Node script.
 
 ```bash
 npm run build
 ```
 
-The above command automatically triggers the `postbuild` script which performs
-the copy. If you prefer an explicit command you can run:
+The above command automatically triggers the `postbuild` script which runs the
+Node copy operation. If you prefer an explicit command you can run:
 
 ```bash
 npm run build:deploy

--- a/pokies-react/copy-dist.js
+++ b/pokies-react/copy-dist.js
@@ -1,0 +1,13 @@
+import { cp } from 'fs/promises';
+import { dirname, resolve } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const source = resolve(__dirname, 'dist');
+const dest = resolve(__dirname, '..', 'Universal Psychology', 'pokies-react');
+
+cp(source, dest, { recursive: true })
+  .catch(err => {
+    console.error('Copy failed:', err);
+    process.exit(1);
+  });

--- a/pokies-react/package.json
+++ b/pokies-react/package.json
@@ -8,7 +8,7 @@
     "build": "vite build",
     "lint": "eslint .",
     "preview": "vite preview",
-    "postbuild": "cp -r dist/* \"../Universal Psychology/pokies-react/\"",
+    "postbuild": "node copy-dist.js",
     "build:deploy": "npm run build && npm run postbuild"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- add small Node copy script and use it in `postbuild`
- document new postbuild behavior in project README files

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684b735a40688327a59d94d8dfd795db